### PR TITLE
fix: correct week number calculation

### DIFF
--- a/utils/winningManager.ts
+++ b/utils/winningManager.ts
@@ -62,7 +62,9 @@ function generateNearestEurojackpotUrl() {
     if (target.getDay() !== 4) {
       target.setMonth(0, 1 + ((4 - target.getDay()) + 7) % 7);
     }
-    const weekNumber = 1 + Math.ceil((firstThursday - target.getTime()) / 6048000);
+    // 604800000 = 7 * 24 * 60 * 60 * 1000 milliseconds in a week
+    const MILLISECONDS_IN_WEEK = 7 * 24 * 60 * 60 * 1000;
+    const weekNumber = 1 + Math.ceil((firstThursday - target.getTime()) / MILLISECONDS_IN_WEEK);
     return weekNumber;
   }
 


### PR DESCRIPTION
## Summary
- fix week number calculation in winningManager to use milliseconds-in-week constant

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6897794a6498832ca09f502f78e2ceeb