### PR TITLE
test: add coverage for store utilities

### DIFF
--- a/stores/__tests__/odds.test.ts
+++ b/stores/__tests__/odds.test.ts
@@ -285,6 +285,19 @@ describe('Odds Store', () => {
       expect(store.cache.data).toBeNull()
       expect(store.cache.timestamp).toBe(0)
     })
+
+    it('should clear error state', async () => {
+      global.$fetch = vi.fn().mockRejectedValue(new Error('fail'))
+
+      const store = useOddsStore()
+      await store.fetchOdds()
+      expect(store.hasError).toBe(true)
+
+      store.clearError()
+
+      expect(store.cache.error).toBeNull()
+      expect(store.hasError).toBe(false)
+    })
   })
 
   describe('utility functions', () => {

--- a/stores/__tests__/tickets.test.ts
+++ b/stores/__tests__/tickets.test.ts
@@ -199,6 +199,17 @@ describe('Tickets Store', () => {
     vi.useRealTimers()
   })
 
+  it('updateConfig does not update URL when shared', async () => {
+    vi.useFakeTimers()
+    const ticketsStore = useTicketsStore()
+    ticketsStore.setLuckyCode('EXISTING', 'SHARED')
+    ticketsStore.updateConfig({ ticketCount: 2 })
+
+    vi.advanceTimersByTime(250)
+    expect(mockHistoryReplace).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
   it('applyUrlConfig with lucky triggers auto-generate and welcome', async () => {
     // @ts-expect-error – global mock
     global.$fetch = vi.fn().mockResolvedValue([])
@@ -275,6 +286,38 @@ describe('Tickets Store', () => {
     expect(ticketsStore.state.error).toBeNull()
     expect(spyResetTickets).toHaveBeenCalled()
     expect(mockHistoryReplace).toHaveBeenCalledWith(null, '', '/')
+  })
+
+  it('clearError resets error state and phase', async () => {
+    const ticketsStore = useTicketsStore()
+
+    ticketsStore.updateConfig({ ticketCount: 0 })
+    await ticketsStore.generate()
+    expect(ticketsStore.state.phase).toBe('error')
+
+    ticketsStore.clearError()
+    expect(ticketsStore.state.error).toBeNull()
+    expect(ticketsStore.state.phase).toBe('fresh')
+
+    // generate valid tickets
+    // @ts-expect-error – global mock
+    global.$fetch = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 1, mainNumbers: [], euroNumbers: [], linesCount: 1 },
+      ])
+    ticketsStore.updateConfig({ ticketCount: 1 })
+    await ticketsStore.generate()
+    expect(ticketsStore.state.phase).toBe('ready')
+
+    // trigger error again while tickets exist
+    ticketsStore.updateConfig({ ticketCount: 0 })
+    await ticketsStore.generate()
+    expect(ticketsStore.state.phase).toBe('error')
+
+    ticketsStore.clearError()
+    expect(ticketsStore.state.error).toBeNull()
+    expect(ticketsStore.state.phase).toBe('ready')
   })
 
   it('getDecoratedTickets merges highlights and sorts by winClass', async () => {


### PR DESCRIPTION
## Summary
- add coverage for odds store error clearing
- test ticket config updates when shared and error clearing behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689f9e9c9174832cb178019097b9616c