### PR TITLE
chore: align components with casino design tokens

### DIFF
--- a/ai_docs/DESIGN_SYSTEM.md
+++ b/ai_docs/DESIGN_SYSTEM.md
@@ -187,7 +187,34 @@ interactive-danger-active    → Danger active
 - Secondary (gold) for brand-related actions
 - Tertiary (platinum) for subtle, low-priority actions
 - Success (emerald) for positive confirmations
-- Danger (burgundy) for destructive actions
+  - Danger (burgundy) for destructive actions
+
+### **5. Status Colors - Feedback & Alerts**
+
+Semantic tokens for application status messaging:
+
+```css
+/* Error */
+error         → Critical failures and destructive actions
+error-light   → Error text/icons on dark surfaces
+error-dark    → Emphasized error backgrounds
+
+/* Warning */
+warning       → Cautionary notices and pending risks
+warning-light → Warning text/icons on dark surfaces
+warning-dark  → Emphasized warning backgrounds
+
+/* Success */
+success       → Positive confirmations and completed actions
+success-light → Success text/icons on dark surfaces
+success-dark  → Emphasized success backgrounds
+```
+
+**Usage Guidelines:**
+
+- Use matching text/background pairs from the same status family
+- Avoid Tailwind default color names (`bg-red-500`, etc.)
+- Reserve emerald premium accents for jackpot visuals, not generic success states
 
 ---
 

--- a/app/components/BatchSimulationConfig.vue
+++ b/app/components/BatchSimulationConfig.vue
@@ -89,7 +89,7 @@
               >Total Cost</span
             >
             <span
-              class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-red-900/50 text-error-light border border-red-400/30"
+              class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-error-dark/50 text-error-light border border-error/30"
             >
               HIGH
             </span>
@@ -125,7 +125,7 @@
               >Break-even Target</span
             >
             <span
-              class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-900/50 text-warning-light border border-yellow-400/30"
+              class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-warning-dark/50 text-warning-light border border-warning/30"
             >
               TARGET
             </span>
@@ -200,7 +200,7 @@
         <button
           v-if="showCancelButton"
           :disabled="disabled && !canCancel"
-          class="bg-red-600 text-content-primary px-5 py-2 rounded-md font-semibold hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-surface-primary disabled:opacity-50 disabled:cursor-not-allowed transition duration-150"
+          class="bg-error text-content-primary px-5 py-2 rounded-md font-semibold hover:bg-error-dark focus:outline-none focus:ring-2 focus:ring-error focus:ring-offset-2 focus:ring-offset-surface-primary disabled:opacity-50 disabled:cursor-not-allowed transition duration-150"
           @click="$emit('cancel')"
         >
           Cancel Simulation

--- a/app/components/BatchSimulationProgress.vue
+++ b/app/components/BatchSimulationProgress.vue
@@ -117,7 +117,7 @@
 
     <div v-if="canCancel" class="text-center">
       <button
-        class="bg-red-600 text-content-primary px-4 py-2 rounded-md font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-surface-primary transition duration-150"
+        class="bg-error text-content-primary px-4 py-2 rounded-md font-medium hover:bg-error-dark focus:outline-none focus:ring-2 focus:ring-error focus:ring-offset-2 focus:ring-offset-surface-primary transition duration-150"
         @click="$emit('cancel')"
       >
         Cancel Simulation

--- a/app/components/MonteCarloPanel.vue
+++ b/app/components/MonteCarloPanel.vue
@@ -2,7 +2,7 @@
   <div>
     <div
       v-if="error"
-      class="text-center text-error bg-red-900/50 border border-red-500 p-3 rounded-md mb-4"
+      class="text-center text-error bg-error-dark/50 border border-error p-3 rounded-md mb-4"
     >
       {{ error }}
     </div>

--- a/app/components/TicketGenerator.vue
+++ b/app/components/TicketGenerator.vue
@@ -84,7 +84,7 @@
                   :class="[
                     'px-4 py-2 text-sm font-medium rounded-md transition duration-150 focus:outline-none focus:ring-2 focus:ring-brand-gold-400',
                     copySuccess
-                      ? 'bg-green-600 text-content-primary'
+                      ? 'bg-success text-content-primary'
                       : 'bg-brand-gold text-casino-blue-dark hover:bg-brand-gold-light',
                   ]"
                   @click="copyShareableUrl"
@@ -233,7 +233,7 @@
 
           <div
             v-else-if="error"
-            class="text-center text-error bg-red-900/50 border border-red-500 p-4 rounded-md"
+            class="text-center text-error bg-error-dark/50 border border-error p-4 rounded-md"
             role="alert"
           >
             {{ error }}

--- a/app/components/TicketItem.vue
+++ b/app/components/TicketItem.vue
@@ -24,7 +24,7 @@
         </Transition>
       </h3>
       <button
-        class="text-content-muted hover:text-error hover:bg-red-900/20 rounded-full p-1 transition-colors duration-200 flex-shrink-0"
+        class="text-content-muted hover:text-error hover:bg-error-dark/20 rounded-full p-1 transition-colors duration-200 flex-shrink-0"
         title="Delete this ticket"
         @click="emit('delete', ticket.id)"
       >


### PR DESCRIPTION
## Summary
- replace default Tailwind colors in UI with semantic casino tokens
- document reusable status color tokens in design system

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2b5777654832cbb83ed01634e0afd